### PR TITLE
Fix broken star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,4 +260,4 @@ A: No. Unlike a VPN or Tor, this program does not hide your traffic from your In
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=GVCoder09/NoDPI&type=Date)](https://www.star-history.com/#GVCoder09/NoDPI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=GVCoder09/NoDPI&type=Date)](https://star-history.dera.page/#GVCoder09/NoDPI&Date)

--- a/README.ru.md
+++ b/README.ru.md
@@ -257,4 +257,4 @@ options:
 
 ## История звезд проекта
 
-[![Star History Chart](https://api.star-history.com/svg?repos=GVCoder09/NoDPI&type=Date)](https://www.star-history.com/#GVCoder09/NoDPI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=GVCoder09/NoDPI&type=Date)](https://star-history.dera.page/#GVCoder09/NoDPI&Date)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken. The stargazer data source it relied on is no longer working, so I have switched it to an alternative that works without an API token. This restores the chart to a working state and keeps the project badge and chart visible for visitors.